### PR TITLE
Fixed lua_import path in the Boxfile

### DIFF
--- a/Boxfile
+++ b/Boxfile
@@ -1,5 +1,5 @@
 {
     "config": {
-        "lua_import": "options.lua"
+        "lua_import": "source/options.lua"
     }
 }


### PR DESCRIPTION
The file `options.lua` was located in a `source` subfolder which caused an error during `toybox update`.